### PR TITLE
Add Facebook image upload script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # CoronaVirus
+
+## facebook_uploader.py
+
+This script demonstrates how to upload images from a local directory to a Facebook page using the Graph API. Captions are loaded from a text file (one caption per line).
+
+1. Install the required package:
+   ```bash
+   pip install requests
+   ```
+2. Update the `IMAGE_DIR`, `CAPTION_FILE`, `PAGE_ID`, and `ACCESS_TOKEN` variables in the script.
+3. Run the script with Python:
+   ```bash
+   python facebook_uploader.py
+   ```
+
+Make sure you have a valid Page access token with permissions to upload photos.

--- a/facebook_uploader.py
+++ b/facebook_uploader.py
@@ -1,0 +1,48 @@
+import os
+import requests
+from pathlib import Path
+
+
+def load_captions(caption_file):
+    """Load captions from a text file."""
+    captions = []
+    with open(caption_file, 'r', encoding='utf-8') as f:
+        for line in f:
+            caption = line.strip()
+            if caption:
+                captions.append(caption)
+    return captions
+
+
+def upload_images(directory, captions, page_id, access_token):
+    """Upload images in directory to a Facebook page with captions."""
+    session = requests.Session()
+    images = sorted(Path(directory).glob('*.*'))
+    for idx, image_path in enumerate(images):
+        if idx < len(captions):
+            caption = captions[idx]
+        else:
+            caption = ''
+        files = {
+            'source': open(image_path, 'rb')
+        }
+        data = {
+            'caption': caption,
+            'access_token': access_token
+        }
+        url = f'https://graph.facebook.com/{page_id}/photos'
+        resp = session.post(url, files=files, data=data)
+        if resp.ok:
+            print(f'Uploaded {image_path.name}')
+        else:
+            print(f'Failed to upload {image_path.name}: {resp.text}')
+
+
+if __name__ == '__main__':
+    IMAGE_DIR = 'path/to/your/image_folder'
+    CAPTION_FILE = 'captions.txt'
+    PAGE_ID = 'your_page_id'
+    ACCESS_TOKEN = 'your_page_access_token'
+
+    captions = load_captions(CAPTION_FILE)
+    upload_images(IMAGE_DIR, captions, PAGE_ID, ACCESS_TOKEN)


### PR DESCRIPTION
## Summary
- add `facebook_uploader.py` with helper to upload local images to a Facebook page
- update README with usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6845acc71db08325a4b08c0690b91ceb