### PR TITLE
Add prototype Facebook Page scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# CoronaVirus
+# Facebook Page Scheduler (Prototype)
+
+This repository contains a **very small prototype** of a web service that
+interacts with the [Meta Graph API](https://developers.facebook.com/docs/graph-api/)
+to schedule and publish posts to Facebook Pages. It is **not** a
+complete product but demonstrates the core building blocks:
+
+* Wrapper around Graph API for text, photo and video posts.
+* In-memory job scheduler for deferred publishing.
+* `FastAPI` application with endpoints for listing pages, creating posts
+  and scheduling them.
+
+## Running locally
+
+```bash
+pip install -r requirements.txt  # requires internet access
+uvicorn app.main:app --reload
+```
+
+## Tests
+
+The project uses `unittest` for basic syntax checks:
+
+```bash
+python -m unittest
+```
+
+## Disclaimer
+
+This code is for educational purposes and **omits many production
+features** such as OAuth flows, persistent storage, background workers,
+webhook handling and comprehensive error checking. Refer to the Meta
+Platform Policies and Graph API documentation before using it in a real
+project.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Minimal Facebook Page scheduler app package."""

--- a/app/facebook.py
+++ b/app/facebook.py
@@ -1,0 +1,73 @@
+"""Helper functions for interacting with Meta Graph API.
+
+This module uses the official Graph API endpoints to perform actions
+such as listing pages or publishing posts. Network calls are performed
+with the ``requests`` library; callers should supply valid Page access
+tokens obtained via the Facebook Login OAuth flow.
+"""
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+from typing import Dict, Any, List
+
+GRAPH_API_BASE = "https://graph.facebook.com/v17.0"
+
+
+class FacebookClient:
+    """Very small wrapper around a subset of the Graph API.
+
+    This implementation is intentionally minimal; production systems
+    should include extensive error handling and token management.
+    """
+
+    def __init__(self, page_access_token: str) -> None:
+        self.token = page_access_token
+
+    def _post(self, path: str, data: Dict[str, Any]) -> Dict[str, Any]:
+        """POST ``data`` to ``path`` and return decoded JSON."""
+        data["access_token"] = self.token
+        body = urllib.parse.urlencode(data).encode()
+        req = urllib.request.Request(f"{GRAPH_API_BASE}/{path}", data=body)
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+
+    def _get(self, path: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        params = params or {}
+        params["access_token"] = self.token
+        query = urllib.parse.urlencode(params)
+        with urllib.request.urlopen(f"{GRAPH_API_BASE}/{path}?{query}") as resp:
+            return json.loads(resp.read().decode())
+
+    # === Page management ==================================================
+    def list_pages(self) -> List[Dict[str, Any]]:
+        """Return pages manageable by the user.
+
+        In a real implementation the user access token would be required
+        to query ``/me/accounts``. For simplicity this function assumes
+        that the provided token is already a Page token and returns basic
+        metadata for that Page.
+        """
+        info = self._get("me")
+        return [info]
+
+    # === Publishing =======================================================
+    def create_text_post(self, page_id: str, message: str) -> Dict[str, Any]:
+        """Publish a simple text post to ``page_id``."""
+        return self._post(f"{page_id}/feed", {"message": message})
+
+    def upload_photo(self, page_id: str, image_url: str, caption: str | None = None) -> Dict[str, Any]:
+        data: Dict[str, Any] = {"url": image_url}
+        if caption:
+            data["caption"] = caption
+        return self._post(f"{page_id}/photos", data)
+
+    def upload_video(self, page_id: str, video_url: str, title: str, description: str) -> Dict[str, Any]:
+        data = {"file_url": video_url, "title": title, "description": description}
+        return self._post(f"{page_id}/videos", data)
+
+    # === Insights ========================================================
+    def page_insights(self, page_id: str, metric: str) -> Dict[str, Any]:
+        """Fetch basic insights for a Page."""
+        return self._get(f"{page_id}/insights", {"metric": metric})

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,45 @@
+"""FastAPI application providing endpoints for Facebook Page scheduling.
+
+The app exposes a subset of the API surface described in the product
+requirements. Function bodies are intentionally short and many advanced
+features (such as authentication persistence, media uploads, analytics
+and webhooks) are left as exercises for a full implementation.
+"""
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+
+from .facebook import FacebookClient
+from .scheduler import scheduler
+
+app = FastAPI(title="FB Scheduler")
+
+
+@app.on_event("startup")
+def _startup() -> None:
+    scheduler.start()
+
+
+@app.on_event("shutdown")
+def _shutdown() -> None:
+    scheduler.shutdown()
+
+
+@app.get("/pages")
+def get_pages(page_token: str) -> list[dict]:
+    """Return manageable pages for the provided Page access token."""
+    fb = FacebookClient(page_token)
+    return fb.list_pages()
+
+
+@app.post("/posts")
+def create_text_post(page_id: str, page_token: str, message: str) -> dict:
+    fb = FacebookClient(page_token)
+    return fb.create_text_post(page_id, message)
+
+
+@app.post("/posts/{post_id}/schedule")
+def schedule_post(post_id: str, seconds_from_now: int) -> dict:
+    """Dummy scheduling endpoint that runs a no-op job."""
+    scheduler.enqueue(seconds_from_now, lambda: None)
+    return {"scheduled": post_id, "run_in": seconds_from_now}

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -1,0 +1,64 @@
+"""Very small in-memory scheduler.
+
+A production-ready system would use a real job queue and persistent
+storage. This module provides a minimal abstraction so that the rest
+of the application can enqueue publishing jobs.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List
+
+
+@dataclass
+class Job:
+    run_at: float
+    func: Callable[[], None]
+    id: int = field(default_factory=int)
+
+
+class Scheduler:
+    def __init__(self) -> None:
+        self.jobs: List[Job] = []
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._running = False
+
+    def start(self) -> None:
+        if not self._running:
+            self._running = True
+            self._thread.start()
+
+    def shutdown(self) -> None:
+        self._running = False
+        self._thread.join(timeout=1)
+
+    def enqueue(self, delay_seconds: float, func: Callable[[], None]) -> int:
+        job = Job(run_at=time.time() + delay_seconds, func=func, id=len(self.jobs) + 1)
+        with self._lock:
+            self.jobs.append(job)
+        return job.id
+
+    def _run(self) -> None:
+        while self._running:
+            now = time.time()
+            to_run: List[Job] = []
+            with self._lock:
+                remaining: List[Job] = []
+                for job in self.jobs:
+                    if job.run_at <= now:
+                        to_run.append(job)
+                    else:
+                        remaining.append(job)
+                self.jobs = remaining
+            for job in to_run:
+                try:
+                    job.func()
+                except Exception:
+                    pass
+            time.sleep(0.5)
+
+
+scheduler = Scheduler()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+requests
+apscheduler

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -1,0 +1,11 @@
+import os
+import py_compile
+import unittest
+
+
+class SyntaxTest(unittest.TestCase):
+    def test_compile(self):
+        for root, _, files in os.walk('app'):
+            for f in files:
+                if f.endswith('.py'):
+                    py_compile.compile(os.path.join(root, f))


### PR DESCRIPTION
## Summary
- add FastAPI-based skeleton for scheduling and publishing posts via the Meta Graph API
- implement minimal in-memory scheduler and Graph API wrapper
- document setup and add syntax check test

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_b_68c1af29db4c832dbbbd9d7f23d5db75